### PR TITLE
Fix typo in tutorial: scalaiformSettings -> scalariformSettings

### DIFF
--- a/tutorial/index.html
+++ b/tutorial/index.html
@@ -119,9 +119,9 @@ sbt compile
     </p>
 
     <p>
-        Our build shows that <code>scalaiformSettings</code> are to be used. This is how
+        Our build shows that <code>scalariformSettings</code> are to be used. This is how
         a plugin's settings are declared. The settings are simply a sequence of descriptors that specify
-        the default build configuration for the given plugin. The appearance of <code>scalaiformSettings</code>
+        the default build configuration for the given plugin. The appearance of <code>scalariformSettings</code>
         here actually tells sbt to format Scala code in a conventional manner before
         performing a compilation. You don't need these settings or this plugin; it is shown
         here merely as an example of how a plugin can be referenced.


### PR DESCRIPTION
Instead of `scalariformSettings`, the setting is referenced to as `scalaiformSettings` (missing "r").
