### PR TITLE
Provide link to documentation of sbt's sbt.Keys

### DIFF
--- a/tutorial/index.html
+++ b/tutorial/index.html
@@ -281,7 +281,7 @@ scalacOptions ++= Seq("-deprecated", "-feature")
     <p>
         sbt declares many standard settings
         e.g. <a href="#code/build.sbt" class="shortcut"><code>scalacOptions</code></a>
-        so you should always look first in sbt's sbt.Keys Scala source to see if there is one you can use before
+        so you should always look first in sbt's <a href="http://www.scala-sbt.org/0.13.1/api/index.html#sbt.Keys$">sbt.Keys Scala source</a> to see if there is one you can use before
         declaring your own.
     </p>
 


### PR DESCRIPTION
Add link to the [official API documentation](http://www.scala-sbt.org/0.13.1/api/index.html#sbt.Keys$) of sbt's `sbt.Keys` object. This makes it easier to find sbt's standard settings.
