### PR TITLE
Upgraded toolchain to the latest versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ name := "hello-sbt"
 
 version := "1.0.0-SNAPSHOT"
 
-scalaVersion := "2.10.3"
+scalaVersion := "2.12.1"
 
 scalacOptions += "-deprecation"
 
@@ -19,7 +19,7 @@ scalariformSettings
 
 // Testing
 
-libraryDependencies += "org.specs2" %% "specs2" % "2.3.10" % "test"
+libraryDependencies += "org.specs2" %% "specs2-core" % "3.8.9" % "test"
 
 
 // Publishing

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.1
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")

--- a/src/test/scala/org/example/HelloSpec.scala
+++ b/src/test/scala/org/example/HelloSpec.scala
@@ -1,10 +1,12 @@
+package org.example
+
 import org.specs2.mutable._
 
 class HelloSpec extends Specification {
 
   "The 'Hello world' string" should {
     "contain 11 characters" in {
-      "Hello world" must have size (11)
+      "Hello world" must have size 11
     }
     "start with 'Hello'" in {
       "Hello world" must startWith("Hello")


### PR DESCRIPTION
- Version change:
  - sbt: 0.13.13
  - scala: 2.12.1
  - specs2: 3.8.9
  - scalariform: 1.6.0
- Minor cleanup of HelloSpec.scala